### PR TITLE
Patch#1: Fixes directories with space on windows

### DIFF
--- a/src/AsynchronousJobs/JobRunner.php
+++ b/src/AsynchronousJobs/JobRunner.php
@@ -165,7 +165,7 @@ class JobRunner
             $lockFile = $this->_lockJob($jobDir);
 
             if ($lockFile) {
-                $jobdir = str_replace("/", DIRECTORY_SEPARATOR, $jobDir);
+                // $jobdir = str_replace("/", DIRECTORY_SEPARATOR, $jobDir);
 
                 $jobData->lockFile = $lockFile;
                 $jobData->job = $job;
@@ -178,7 +178,7 @@ class JobRunner
 
                 file_put_contents("$jobDir/in.serialize", serialize($data));
 
-                $cmd = $this->getCmd(realpath(__DIR__ . "/../../bin/AsynchronousJobsRun.php") . " \"$jobDir\" >> $logFile");
+                $cmd = $this->getCmd('"'.realpath(__DIR__ . "/../../bin/AsynchronousJobsRun.php") . "\" $jobDir >> $logFile");
                 if (substr(php_uname(), 0, 7) == "Windows") {
                     $WshShell = new \COM("WScript.Shell");
                     $WshShell->Run("$cmd /C dir /S %windir%", 0, false);

--- a/src/AsynchronousJobs/JobRunner.php
+++ b/src/AsynchronousJobs/JobRunner.php
@@ -59,7 +59,8 @@ class JobRunner
     }
 
     protected function getCmd($cmd) {
-        return PHP_BINARY . " $cmd";
+        echo 'cmd: "'. PHP_BINARY .'" '.  $cmd."\n";
+        return '"'. PHP_BINARY .'" '. $cmd;
     }
 
     /**
@@ -74,7 +75,7 @@ class JobRunner
         }
         // Check if exec is enabled on this server.
         if (substr(php_uname(), 0, 7) == "Windows") {
-            try {
+            try {                
                 $WshShell = new \COM("WScript.Shell");
                 $WshShell->Run($this->getCmd('-v /C dir /S %windir%'), 0, false);
                 $this->exec = true;
@@ -123,7 +124,7 @@ class JobRunner
      */
     protected function _getJobDirectory(Job $job)
     {
-        $jobDir = $this->getDirectory() . '/' . $job->getId();
+        $jobDir = $this->getDirectory() . DIRECTORY_SEPARATOR . $job->getId();
         $this->_prepareDirectory($jobDir);
 
         return $jobDir;
@@ -164,19 +165,20 @@ class JobRunner
             $lockFile = $this->_lockJob($jobDir);
 
             if ($lockFile) {
+                $jobdir = str_replace("/", DIRECTORY_SEPARATOR, $jobDir);
+
                 $jobData->lockFile = $lockFile;
                 $jobData->job = $job;
                 $jobData->jobDir = $jobDir;
 
                 $this->runningJobs[spl_object_hash($job)] = $jobData;
 
-
                 $data = $job->getData();
                 $data['___class'] = get_class($job);
 
                 file_put_contents("$jobDir/in.serialize", serialize($data));
 
-                $cmd = $this->getCmd(__DIR__ . "/../../bin/AsynchronousJobsRun.php \"$jobDir\" >> $logFile");
+                $cmd = $this->getCmd(realpath(__DIR__ . "/../../bin/AsynchronousJobsRun.php") . " \"$jobDir\" >> $logFile");
                 if (substr(php_uname(), 0, 7) == "Windows") {
                     $WshShell = new \COM("WScript.Shell");
                     $WshShell->Run("$cmd /C dir /S %windir%", 0, false);

--- a/src/AsynchronousJobs/JobRunner.php
+++ b/src/AsynchronousJobs/JobRunner.php
@@ -58,8 +58,7 @@ class JobRunner
         return self::$_instance;
     }
 
-    protected function getCmd($cmd) {
-        echo 'cmd: "'. PHP_BINARY .'" '.  $cmd."\n";
+    protected function getCmd($cmd) {        
         return '"'. PHP_BINARY .'" '. $cmd;
     }
 


### PR DESCRIPTION
Hi Oliver,

I noticed if paths contains space, the dcom doesn't like it much.
Also all folders on windows must have backslash as directory separator.
This attempts to fix this.
